### PR TITLE
Adds base relayer

### DIFF
--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -1,8 +1,7 @@
 from kafka import KafkaProducer
 
 from .event_emitter import EventEmitter
-from .exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError, ConfigurationError  # noqa
-
+from .exceptions import ConfigurationError
 
 __version__ = '0.0.1'
 

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -1,0 +1,33 @@
+from kafka import KafkaProducer
+
+from .event_emitter import EventEmitter
+from .exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError, ConfigurationError  # noqa
+
+
+__version__ = '0.0.1'
+
+
+class Relayer(object):
+
+    def __init__(self, logging_topic, context_handler_class, kafka_hosts=None):
+        self.logging_topic = logging_topic
+        if not kafka_hosts:
+            raise ConfigurationError()
+        producer = KafkaProducer(bootstrap_servers=kafka_hosts)
+        emitter = EventEmitter(producer)
+        self.context = context_handler_class(emitter)
+
+    def emit(self, event_type, event_subtype, payload, partition_key=None):
+        payload = {
+            'event_type': event_type,
+            'event_subtype': event_subtype,
+            'payload': payload
+        }
+        self.context.emit(event_type, payload, partition_key)
+
+    def log(self, log_level, payload):
+        message = {
+            'log_level': log_level,
+            'payload': payload
+        }
+        self.context.log(message)

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -1,0 +1,29 @@
+import json
+from uuid import UUID
+
+from .exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError
+
+
+class EventEmitter(object):
+
+    def __init__(self, producer):
+        self.producer = producer
+
+    def emit(self, topic, message, partition_key=None):
+
+        if isinstance(partition_key, str):
+            partition_key = partition_key.encode('utf-8')
+        elif isinstance(partition_key, UUID):
+            partition_key = partition_key.bytes
+        elif partition_key is not None:
+            raise UnsupportedPartitionKeyTypeError(partition_key.__class__)
+
+        try:
+            message = json.dumps(message).encode('utf-8')
+        except TypeError as error:
+            raise NonJSONSerializableMessageError(str(error))
+
+        self.producer.send(topic, key=partition_key, value=message)
+
+    def flush(self):
+        self.producer.flush()

--- a/relayer/exceptions.py
+++ b/relayer/exceptions.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+
+class RelayerError(Exception):
+    pass
+
+
+class NonJSONSerializableMessageError(RelayerError):
+    pass
+
+
+class ConfigurationError(RelayerError):
+    def __init__(self):
+        super().__init__('Cannot create relayer object if no kafka hosts are provided')
+
+
+class UnsupportedPartitionKeyTypeError(RelayerError):
+    def __init__(self, provided_type):
+        super().__init__('Unsuported partition key type provided, got {}, expected {} or {}'.format(
+            provided_type.__name__, str.__name__, UUID.__name__))

--- a/relayer/utils/__init__.py
+++ b/relayer/utils/__init__.py
@@ -1,0 +1,3 @@
+def get_elapsed_time_in_milliseconds(start_time, end_time):
+    elapsed_time = end_time - start_time
+    return elapsed_time.microseconds / 1000.0 + elapsed_time.seconds * 1000

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+import sure  # noqa
+from unittest import TestCase
+
+from .mocks import MockedProducer
+
+
+class BaseTestCase(TestCase):
+    def _setup_kafka_producer_mock(self, kafka_producer_mock):
+        mock_instance = MockedProducer()
+        kafka_producer_mock.return_value = mock_instance
+        self.producer = mock_instance

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,26 @@
+from collections import defaultdict
+
+
+class MockedProducer(object):
+    def __init__(self):
+        self.produced_messages = defaultdict(list)
+        self.flushed = False
+
+    def send(self, topic, value=None, key=None):
+        self.produced_messages[topic].append((value, key, ))
+
+    def flush(self):
+        self.flushed = True
+
+
+class MockedContextHandler(object):
+    def __init__(self, emitter):
+        self.emitter = emitter
+
+    def emit(self, topic, message, partition_key=None):
+        self.topic = topic
+        self.message = message
+        self.partition_key = partition_key
+
+    def log(self, message):
+        self.log_message = message

--- a/tests/test_event_emitter.py
+++ b/tests/test_event_emitter.py
@@ -1,0 +1,47 @@
+from uuid import uuid4
+from datetime import datetime
+
+from relayer import EventEmitter
+from relayer.exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError
+
+from . import BaseTestCase
+from .mocks import MockedProducer
+
+
+class TestEventEmitter(BaseTestCase):
+
+    def setUp(self):
+        self.producer = MockedProducer()
+        self.emitter = EventEmitter(self.producer)
+
+    def _get_topic_messages(self, topic):
+        return self.producer.produced_messages[topic]
+
+    def test_sending_message(self):
+        self.emitter.emit('foo', 'bar')
+        messages = self._get_topic_messages('foo')
+        messages.should.have.length_of(1)
+        messages[0][0].should.equal(b'"bar"')
+
+    def test_throws_if_not_sending_json_serializable(self):
+        self.emitter.emit.when.called_with('foo', datetime.utcnow()).should.throw(NonJSONSerializableMessageError)
+
+    def test_incorrect_partition_key(self):
+        self.emitter.emit.when.called_with('foo', 'bar', datetime.utcnow()).should.throw(UnsupportedPartitionKeyTypeError)
+
+    def test_string_partition_key(self):
+        self.emitter.emit('foo', 'bar', partition_key='key')
+        messages = self._get_topic_messages('foo')
+        messages.should.have.length_of(1)
+        messages[0][1].should.equal(b'key')
+
+    def test_uuid_partition_key(self):
+        key = uuid4()
+        self.emitter.emit('foo', 'bar', partition_key=key)
+        messages = self._get_topic_messages('foo')
+        messages.should.have.length_of(1)
+        messages[0][1].should.equal(key.bytes)
+
+    def test_flush(self):
+        self.emitter.flush()
+        self.producer.flushed.should.be.true

--- a/tests/test_relayer.py
+++ b/tests/test_relayer.py
@@ -1,0 +1,41 @@
+from unittest import mock
+
+from relayer import Relayer
+from relayer.exceptions import ConfigurationError
+
+from . import BaseTestCase
+from .mocks import MockedContextHandler
+
+
+class TestRelayer(BaseTestCase):
+
+    @mock.patch('relayer.KafkaProducer')
+    def setUp(self, kafka_producer_mock):
+        self._setup_kafka_producer_mock(kafka_producer_mock)
+        self.relayer = Relayer('log', MockedContextHandler, kafka_hosts='foo')
+
+    def test_requires_kafka_hosts(self):
+        Relayer.when.called_with('foo', MockedContextHandler).should.throw(ConfigurationError)
+
+    def test_emit(self):
+        self.relayer.emit('type', 'subtype', 'payload')
+        self.relayer.context.topic.should.equal('type')
+
+    def test_emit_with_partition_key(self):
+        self.relayer.emit('type', 'subtype', 'payload', 'key')
+        self.relayer.context.partition_key.should.equal('key')
+        context_message = self.relayer.context.message
+        context_message.should.have.key('event_type')
+        context_message.should.have.key('event_subtype')
+        context_message.should.have.key('payload')
+        context_message['event_type'].should.equal('type')
+        context_message['event_subtype'].should.equal('subtype')
+        context_message['payload'].should.equal('payload')
+
+    def test_log(self):
+        self.relayer.log('info', 'message')
+        log_message = self.relayer.context.log_message
+        log_message.should.have.key('log_level')
+        log_message.should.have.key('payload')
+        log_message['log_level'].should.equal('info')
+        log_message['payload'].should.equal('message')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+
+from relayer import utils
+
+from . import BaseTestCase
+
+
+class TestUtils(BaseTestCase):
+
+    def test_elapsed_time_in_milliseconds(self):
+        start_time = datetime(2016, 6, 21, 15, 12, 5, 500000)
+        end_time = datetime(2016, 6, 21, 15, 12, 6, 600000)
+        milliseconds = utils.get_elapsed_time_in_milliseconds(start_time, end_time)
+        milliseconds.should.equal(1100.0)
+        end_time = datetime(2016, 6, 21, 15, 12, 6, 600500)
+        milliseconds = utils.get_elapsed_time_in_milliseconds(start_time, end_time)
+        milliseconds.should.equal(1100.5)


### PR DESCRIPTION
The Relayer class is not expected to be used by clients, instead the clients
will use wrappers according their stack. The actual wrappers will come
soon.

- [x] @pablasso 
- [ ] @rpfernando 

Note, the build will fail since won't add test yet, but the linter should succeed.