### PR TITLE
Adds RPCRelayer

### DIFF
--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -11,7 +11,6 @@ def make_rpc_relayer(logging_topic, kafka_hosts=None):
 
     def decorator(function):
         def wrapper(*args, **kwargs):
-            function.__qualname__
             start_time = datetime.utcnow()
             kwargs['relayer'] = event_relayer
             context.start_request()

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -1,0 +1,28 @@
+from relayer import Relayer, utils
+from .rpc_context_handler import RPCContextHandler
+
+from datetime import datetime
+
+
+def make_rpc_relayer(logging_topic, kafka_hosts=None):
+
+    event_relayer = Relayer(logging_topic, RPCContextHandler, kafka_hosts=kafka_hosts)
+    context = event_relayer.context
+
+    def decorator(function):
+        def wrapper(*args, **kwargs):
+            function.__qualname__
+            start_time = datetime.utcnow()
+            kwargs['relayer'] = event_relayer
+            context.start_request()
+            service_response = function(*args, **kwargs)
+            end_time = datetime.utcnow()
+            request_log = {
+                'date': start_time.isoformat(),
+                'service': function.__qualname__,
+                'service_time': utils.get_elapsed_time_in_milliseconds(start_time, end_time)
+            }
+            context.end_request(logging_topic, request_log)
+            return service_response
+        return wrapper
+    return decorator

--- a/relayer/rpc/rpc_context_handler.py
+++ b/relayer/rpc/rpc_context_handler.py
@@ -1,0 +1,24 @@
+class RPCContextHandler(object):
+    def __init__(self, event_emitter):
+        self.event_emitter = event_emitter
+        self.kafka_producer_request_logs = []
+
+    def start_request(self):
+        self.kafka_producer_request_logs = []
+
+    def emit(self, topic, message, partition_key=None):
+        self.event_emitter.emit(topic, message, partition_key)
+        # It is important to first emit the message before appending to the log list so if the emit call fails because
+        # the messsage is malformed, the final log message doesn't fail for the same reason.
+        self.kafka_producer_request_logs.append(message)
+
+    def log(self, message):
+        self.kafka_producer_request_logs.append(message)
+
+    def end_request(self, logging_topic, request_log):
+        log_entry = {}
+        log_entry.update(request_log)
+        log_entry['lines'] = self.kafka_producer_request_logs
+
+        self.event_emitter.emit(logging_topic, log_entry)
+        self.event_emitter.flush()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,3 +9,6 @@ class BaseTestCase(TestCase):
         mock_instance = MockedProducer()
         kafka_producer_mock.return_value = mock_instance
         self.producer = mock_instance
+
+    def _get_topic_messages(self, topic):
+        return self.producer.produced_messages[topic]

--- a/tests/test_event_emitter.py
+++ b/tests/test_event_emitter.py
@@ -14,9 +14,6 @@ class TestEventEmitter(BaseTestCase):
         self.producer = MockedProducer()
         self.emitter = EventEmitter(self.producer)
 
-    def _get_topic_messages(self, topic):
-        return self.producer.produced_messages[topic]
-
     def test_sending_message(self):
         self.emitter.emit('foo', 'bar')
         messages = self._get_topic_messages('foo')

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -1,0 +1,60 @@
+import json
+from unittest import mock
+
+from relayer.rpc import make_rpc_relayer
+
+from . import BaseTestCase
+
+
+class TestRPCRelayer(BaseTestCase):
+
+    @mock.patch('relayer.KafkaProducer')
+    def setUp(self, kafka_producer_mock):
+        self._setup_kafka_producer_mock(kafka_producer_mock)
+
+        relayer = make_rpc_relayer('logging_topic', kafka_hosts='kafka')
+
+        @relayer
+        def rpc_method(value, relayer=None):
+            relayer.emit('type', 'subtype', 'payload')
+            relayer.log('info', 'message')
+            return value
+
+        self.rpc_method = rpc_method
+
+    def test_input_and_output_works(self):
+        self.rpc_method(True).should.be.true
+        self.rpc_method(False).should.be.false
+
+    def test_emitted_messages(self):
+        self.rpc_method(True)
+        messages = self._get_topic_messages('type')
+        messages.should.have.length_of(1)
+        message = json.loads(messages[0][0].decode('utf-8'))
+
+        message.should.have.key('event_type')
+        message.should.have.key('event_subtype')
+        message.should.have.key('payload')
+        message['event_type'].should.equal('type')
+        message['event_subtype'].should.equal('subtype')
+        message['payload'].should.equal('payload')
+
+    def test_log(self):
+        self.rpc_method(True)
+        messages = self._get_topic_messages('logging_topic')
+        messages.should.have.length_of(1)
+        message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('date')
+        message.should.have.key('service')
+        message.should.have.key('service_time')
+        message.should.have.key('lines')
+        message['lines'].should.have.length_of(2)
+        first_line = message['lines'][0]
+        first_line.should.have.key('event_type')
+        first_line.should.have.key('event_subtype')
+        first_line.should.have.key('payload')
+        second_line = message['lines'][1]
+        second_line.should.have.key('log_level')
+        second_line.should.have.key('payload')
+        second_line['log_level'].should.equal('info')
+        second_line['payload'].should.equal('message')


### PR DESCRIPTION
The RPCRelayer works by creating a relayer decorator with the kafka
information, that decorator is used on the rpc method you wish to add
logging capabilities, since every method gets a single producer which only
reference lives on the stack this makes it thread safe without hassles.

- [ ] @pablasso 
- [x] @rpfernando 
