### PR TITLE
Adds relayer.test.RelayerPatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ class MyTestCase(TestCase):
         self.relayer_patch.stop()
 ```
 
-If you need to examine what would be written to kafka when patching relayer you can examine the `mockec_producer` property from the RelayerPatch object, this object has a dictionary named `produced_messages` where the key is the name of the topic and the value is a list of tuples with the messages and the partition key used (if any).
+If you need to examine what would be written to kafka when patching relayer you can examine the `mocked_producer` property from the RelayerPatch object, this object has a dictionary named `produced_messages` where the key is the name of the topic and the value is a list of tuples with the messages and the partition key used (if any).
 
 ## Hacking
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 3. [Usage](#usage)
     1. [Flask](#flask)
     2. [RPC](#rpc)
+    3. [Disable for testing](#disable-for-testing)
 4. [Hacking](#hacking)
     1. [Setup](#setup)
     2. [Testing](#testing)
@@ -214,7 +215,29 @@ class RPCHandler(object):
         pass
 ```
 
+### Disable for testing
 
+When running tests you usally need to mock the relayer so it doesn't try to connect to kafka while running the tests, to ease that relayer includes the `relayer.test` package to help you mock it.
+
+Example test file:
+
+```python
+from unittest import TestCase
+
+from relayer.test import RelayerPatch
+
+class MyTestCase(TestCase):
+
+    def setUp(self):
+        self.relayer_patch = RelayerPatch()
+        # After the following line relayer will be patcher and it won't try to connect with kafka
+        self.relayer_patch.start()
+
+    def tearDown(self):
+        self.relayer_patch.stop()
+```
+
+If you need to examine what would be written to kafka when patching relayer you can examine the `mockec_producer` property from the RelayerPatch object, this object has a dictionary named `produced_messages` where the key is the name of the topic and the value is a list of tuples with the messages and the partition key used (if any).
 
 ## Hacking
 

--- a/relayer/test/__init__.py
+++ b/relayer/test/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+from .relayer_patch import RelayerPatch
+from .mocked_producer import MockedProducer

--- a/relayer/test/mocked_producer.py
+++ b/relayer/test/mocked_producer.py
@@ -1,0 +1,13 @@
+from collections import defaultdict
+
+
+class MockedProducer(object):
+    def __init__(self):
+        self.produced_messages = defaultdict(list)
+        self.flushed = False
+
+    def send(self, topic, value=None, key=None):
+        self.produced_messages[topic].append((value, key, ))
+
+    def flush(self):
+        self.flushed = True

--- a/relayer/test/relayer_patch.py
+++ b/relayer/test/relayer_patch.py
@@ -1,0 +1,17 @@
+from unittest import mock
+
+from .mocked_producer import MockedProducer
+
+
+class RelayerPatch(object):
+
+    def __init__(self):
+        self.patcher = mock.patch('relayer.KafkaProducer')
+
+    def start(self):
+        kafka_producer_mock = self.patcher.start()
+        self.mocked_producer = MockedProducer()
+        kafka_producer_mock.return_value = self.mocked_producer
+
+    def stop(self):
+        self.patcher.stop()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,14 +1,19 @@
 import sure  # noqa
 from unittest import TestCase
 
-from .mocks import MockedProducer
+from relayer.test import RelayerPatch
 
 
 class BaseTestCase(TestCase):
-    def _setup_kafka_producer_mock(self, kafka_producer_mock):
-        mock_instance = MockedProducer()
-        kafka_producer_mock.return_value = mock_instance
-        self.producer = mock_instance
+
+    def setUp(self):
+        self.relayer_patch = RelayerPatch()
+        self.relayer_patch.start()
+        self.producer = self.relayer_patch.mocked_producer
+
+    def tearDown(self):
+        if hasattr(self, 'relayer_patch'):
+            self.relayer_patch.stop()
 
     def _get_topic_messages(self, topic):
         return self.producer.produced_messages[topic]

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,18 +1,3 @@
-from collections import defaultdict
-
-
-class MockedProducer(object):
-    def __init__(self):
-        self.produced_messages = defaultdict(list)
-        self.flushed = False
-
-    def send(self, topic, value=None, key=None):
-        self.produced_messages[topic].append((value, key, ))
-
-    def flush(self):
-        self.flushed = True
-
-
 class MockedContextHandler(object):
     def __init__(self, emitter):
         self.emitter = emitter

--- a/tests/test_event_emitter.py
+++ b/tests/test_event_emitter.py
@@ -2,10 +2,10 @@ from uuid import uuid4
 from datetime import datetime
 
 from relayer import EventEmitter
+from relayer.test import MockedProducer
 from relayer.exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError
 
 from . import BaseTestCase
-from .mocks import MockedProducer
 
 
 class TestEventEmitter(BaseTestCase):

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 import flask
 
@@ -10,9 +9,8 @@ from . import BaseTestCase
 
 class FlaskRelayerTestCase(BaseTestCase):
 
-    @mock.patch('relayer.KafkaProducer')
-    def setUp(self, kafka_producer_mock):
-        self._setup_kafka_producer_mock(kafka_producer_mock)
+    def setUp(self):
+        super().setUp()
         app = flask.Flask(__name__)
         self.app = app
         self.client = self.app.test_client()

--- a/tests/test_relayer.py
+++ b/tests/test_relayer.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from relayer import Relayer
 from relayer.exceptions import ConfigurationError
 
@@ -9,9 +7,8 @@ from .mocks import MockedContextHandler
 
 class TestRelayer(BaseTestCase):
 
-    @mock.patch('relayer.KafkaProducer')
-    def setUp(self, kafka_producer_mock):
-        self._setup_kafka_producer_mock(kafka_producer_mock)
+    def setUp(self):
+        super().setUp()
         self.relayer = Relayer('log', MockedContextHandler, kafka_hosts='foo')
 
     def test_requires_kafka_hosts(self):

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 from relayer.rpc import make_rpc_relayer
 
@@ -8,10 +7,8 @@ from . import BaseTestCase
 
 class TestRPCRelayer(BaseTestCase):
 
-    @mock.patch('relayer.KafkaProducer')
-    def setUp(self, kafka_producer_mock):
-        self._setup_kafka_producer_mock(kafka_producer_mock)
-
+    def setUp(self):
+        super().setUp()
         relayer = make_rpc_relayer('logging_topic', kafka_hosts='kafka')
 
         @relayer


### PR DESCRIPTION
RelayerPatch is a patching utility so consumers of this library can easily
mock kafka communication when running tests.

This also refactors the tests of relayer to use RelayerPatch and updates
the documentation on its usage.
- [x] @pablasso 
- [ ] @rpfernando 

