### PR TITLE
Adds topic_prefix and topic_suffix options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Relayer supports two different clients, RPC and Flask, depending on which client
 
 When you do a `relayer.emit` the message gets sent immediately to kafka, but also a copy gets saved for the purpose of log aggregation. When you create the relayer a `logging_topic` needs to be provided, this argument represents a kafka topic where log information gets written, all the messages written by `relayer.emit` and `relayer.log` gets aggregated for every request (or RPC call) and gets written to the specified `logging_topic` on kafka, so it can later be piped to an ELK stack or similar systems. This special log message also contains metadata related to the request, such as the timestamp and how long did it take to process the request.
 
+Both RPC and Flask relayer support the optional parameters `topic_prefix` and `topic_suffix`. When `topic_prefix` is present all message sent to any kafka topic will prepend the value of `topic_prefix` to the topic name, that includes both the logging topic value and the topics used on `emit` calls. `topic_suffix` does exactly the same but instead of prepending, it appends its value to the topic names, this might be useful to namespace topics if you want to use the same kafka cluster to host messages from a few different environments.
+
 
 ### Flask
 

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -3,17 +3,17 @@ from kafka import KafkaProducer
 from .event_emitter import EventEmitter
 from .exceptions import ConfigurationError
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 
 class Relayer(object):
 
-    def __init__(self, logging_topic, context_handler_class, kafka_hosts=None):
+    def __init__(self, logging_topic, context_handler_class, kafka_hosts=None, topic_prefix='', topic_suffix=''):
         self.logging_topic = logging_topic
         if not kafka_hosts:
             raise ConfigurationError()
         producer = KafkaProducer(bootstrap_servers=kafka_hosts)
-        emitter = EventEmitter(producer)
+        emitter = EventEmitter(producer, topic_prefix=topic_prefix, topic_suffix=topic_suffix)
         self.context = context_handler_class(emitter)
 
     def emit(self, event_type, event_subtype, payload, partition_key=None):

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -6,10 +6,14 @@ from .exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKey
 
 class EventEmitter(object):
 
-    def __init__(self, producer):
+    def __init__(self, producer, topic_prefix='', topic_suffix=''):
         self.producer = producer
+        self.topic_prefix = topic_prefix
+        self.topic_suffix = topic_suffix
 
     def emit(self, topic, message, partition_key=None):
+
+        topic = '{0}{1}{2}'.format(self.topic_prefix, topic, self.topic_suffix)
 
         if isinstance(partition_key, str):
             partition_key = partition_key.encode('utf-8')

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -5,13 +5,15 @@ from .logging_middleware import LoggingMiddleware
 
 class FlaskRelayer(object):
 
-    def __init__(self, app=None, logging_topic=None, kafka_hosts=None):
+    def __init__(self, app=None, logging_topic=None, kafka_hosts=None, topic_prefix='', topic_suffix=''):
         if app:
-            self.init_app(app, logging_topic, kafka_hosts=kafka_hosts)
+            self.init_app(app, logging_topic, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
+                          topic_suffix=topic_suffix)
 
-    def init_app(self, app, logging_topic, kafka_hosts=None):
+    def init_app(self, app, logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix=''):
         kafka_hosts = kafka_hosts or app.config.get('KAFKA_HOSTS')
-        self.event_relayer = Relayer(logging_topic, FlaskContextHandler, kafka_hosts=kafka_hosts)
+        self.event_relayer = Relayer(logging_topic, FlaskContextHandler, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
+                                     topic_suffix=topic_suffix)
         app.wsgi_app = LoggingMiddleware(app, app.wsgi_app, self.event_relayer.context, logging_topic)
 
     def emit(self, *args, **kwargs):

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -4,9 +4,10 @@ from .rpc_context_handler import RPCContextHandler
 from datetime import datetime
 
 
-def make_rpc_relayer(logging_topic, kafka_hosts=None):
+def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix=''):
 
-    event_relayer = Relayer(logging_topic, RPCContextHandler, kafka_hosts=kafka_hosts)
+    event_relayer = Relayer(logging_topic, RPCContextHandler, kafka_hosts=kafka_hosts,
+                            topic_prefix=topic_prefix, topic_suffix=topic_suffix)
     context = event_relayer.context
 
     def decorator(function):

--- a/tests/test_event_emitter.py
+++ b/tests/test_event_emitter.py
@@ -42,3 +42,13 @@ class TestEventEmitter(BaseTestCase):
     def test_flush(self):
         self.emitter.flush()
         self.producer.flushed.should.be.true
+
+    def test_message_prefix(self):
+        self.emitter = EventEmitter(self.producer, topic_prefix='test_')
+        self.emitter.emit('foo', 'bar')
+        self._get_topic_messages('test_foo').should.have.length_of(1)
+
+    def test_message_suffix(self):
+        self.emitter = EventEmitter(self.producer, topic_suffix='_test')
+        self.emitter.emit('foo', 'bar')
+        self._get_topic_messages('foo_test').should.have.length_of(1)

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -14,7 +14,7 @@ class FlaskRelayerTestCase(BaseTestCase):
         app = flask.Flask(__name__)
         self.app = app
         self.client = self.app.test_client()
-        self.relayer = FlaskRelayer(app, 'logging_topic', 'kafka')
+        self.relayer = FlaskRelayer(app, 'logging', 'kafka', topic_prefix='test_', topic_suffix='_topic')
 
         @app.route('/test')
         def test_emit():
@@ -27,7 +27,7 @@ class FlaskRelayerTestCase(BaseTestCase):
 
     def test_emitted_messages(self):
         self.client.get('/test')
-        messages = self._get_topic_messages('type')
+        messages = self._get_topic_messages('test_type_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
 
@@ -40,7 +40,7 @@ class FlaskRelayerTestCase(BaseTestCase):
 
     def test_log(self):
         self.client.get('/test')
-        messages = self._get_topic_messages('logging_topic')
+        messages = self._get_topic_messages('test_logging_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
         message.should.have.key('date')

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -9,7 +9,7 @@ class TestRPCRelayer(BaseTestCase):
 
     def setUp(self):
         super().setUp()
-        relayer = make_rpc_relayer('logging_topic', kafka_hosts='kafka')
+        relayer = make_rpc_relayer('logging', kafka_hosts='kafka', topic_prefix='test_', topic_suffix='_topic')
 
         @relayer
         def rpc_method(value, relayer=None):
@@ -25,7 +25,7 @@ class TestRPCRelayer(BaseTestCase):
 
     def test_emitted_messages(self):
         self.rpc_method(True)
-        messages = self._get_topic_messages('type')
+        messages = self._get_topic_messages('test_type_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
 
@@ -38,7 +38,7 @@ class TestRPCRelayer(BaseTestCase):
 
     def test_log(self):
         self.rpc_method(True)
-        messages = self._get_topic_messages('logging_topic')
+        messages = self._get_topic_messages('test_logging_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
         message.should.have.key('date')


### PR DESCRIPTION
When present topic_prefix and topic_suffix preppends or append its value to
all the topic names were messages are emitted, both for the log aggregation topic
and the topics for emit calls.

This feature is useful to namespace topics if you have a single kafka cluster storing
messages for more than one environment.

resolves #9 

- [x] @pablasso 
- [x] @rpfernando 

