### PR TITLE
Makes Relayer log kafka messages to its module logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,11 +245,9 @@ If you need to examine what would be written to kafka when patching relayer you 
 
 ### Settings for development
 
-You might not have kafka running on your local environment, on those cases you can use `RelayerPatch` to avoid hitting kafka on your local,
-just as described on the [Disable for testing](#disable-for-testing) section.
+You might not have kafka running on your local environment, on those cases you can use `RelayerPatch` to avoid hitting kafka on your local, just as described on the [Disable for testing](#disable-for-testing) section.
 
-If you do that you might still be interested on being able to see on your console the messages produced to kafka, for that `relayer` logs
-all the messages it receives to its logger so you can configure it to be shown on your environment.
+If you do that you might still be interested on being able to see on your console the messages produced to kafka, for that `relayer` logs all the messages it receives to its logger so you can configure it to be shown on your environment.
 
 ```python
 import logging

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
     1. [Flask](#flask)
     2. [RPC](#rpc)
     3. [Disable for testing](#disable-for-testing)
+    4. [Settings for development](#settings-for-development)
 4. [Hacking](#hacking)
     1. [Setup](#setup)
     2. [Testing](#testing)
@@ -240,6 +241,24 @@ class MyTestCase(TestCase):
 ```
 
 If you need to examine what would be written to kafka when patching relayer you can examine the `mocked_producer` property from the RelayerPatch object, this object has a dictionary named `produced_messages` where the key is the name of the topic and the value is a list of tuples with the messages and the partition key used (if any).
+
+
+### Settings for development
+
+You might not have kafka running on your local environment, on those cases you can use `RelayerPatch` to avoid hitting kafka on your local,
+just as described on the [Disable for testing](#disable-for-testing) section.
+
+If you do that you might still be interested on being able to see on your console the messages produced to kafka, for that `relayer` logs
+all the messages it receives to its logger so you can configure it to be shown on your environment.
+
+```python
+import logging
+
+relayer_logger = logging.getLogger('relayer')
+relayer_logger.setLevel(logging.DEBUG)              #  Relayer always log its message on the DEBUG level
+handler = logging.StreamHandler()
+relayer_logger.addHandler(logging.StreamHandler())  #  Stream handler outputs to stdout, you might or not need to do This
+```
 
 ## Hacking
 

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -3,7 +3,7 @@ from kafka import KafkaProducer
 from .event_emitter import EventEmitter
 from .exceptions import ConfigurationError
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 
 class Relayer(object):

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -2,6 +2,7 @@ import json
 from uuid import UUID
 
 from .exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError
+from .logger import log_kafka_message
 
 
 class EventEmitter(object):
@@ -14,6 +15,8 @@ class EventEmitter(object):
     def emit(self, topic, message, partition_key=None):
 
         topic = '{0}{1}{2}'.format(self.topic_prefix, topic, self.topic_suffix)
+
+        log_kafka_message(topic, message, partition_key=partition_key)
 
         if isinstance(partition_key, str):
             partition_key = partition_key.encode('utf-8')

--- a/relayer/logger.py
+++ b/relayer/logger.py
@@ -1,0 +1,8 @@
+import logging
+
+
+logger = logging.getLogger('relayer')
+
+
+def log_kafka_message(topic, payload, partition_key=None):
+    logger.debug('Writing to kafka topic: %s, partition_key: %s, message: %s', topic, partition_key, payload)

--- a/relayer/logger.py
+++ b/relayer/logger.py
@@ -5,4 +5,4 @@ logger = logging.getLogger('relayer')
 
 
 def log_kafka_message(topic, payload, partition_key=None):
-    logger.debug('Writing to kafka topic: %s, partition_key: %s, message: %s', topic, partition_key, payload)
+    logger.debug('topic: %s, partition_key: %s, message: %s', topic, partition_key, payload)


### PR DESCRIPTION
Kafka messages are now also logged on relayer's module logger so the logged messages can be easily seen on development environments.

resolves #11 

- [ ] @rpfernando 
- [x] @pablasso 