### PR TITLE
Giving priority to proxied IP

### DIFF
--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -40,7 +40,7 @@ class LoggingMiddleware(object):
                 'path': environ.get('PATH_INFO'),
                 'query_string': environ.get('QUERY_STRING'),
                 'remote_addr': environ.get('X_REAL_IP', environ.get('REMOTE_ADDR')),
-                'x_forwarded_for': environ.get('X_Forwarded_For'),
+                'x_forwarded_for': environ.get('X_FORWARDED_FOR'),
                 'status': status_code,
                 'content_length': content_length,
                 'request_time': elapsed_time_milliseconds

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -39,7 +39,7 @@ class LoggingMiddleware(object):
                 'method': environ.get('REQUEST_METHOD'),
                 'path': environ.get('PATH_INFO'),
                 'query_string': environ.get('QUERY_STRING'),
-                'remote_addr': environ.get('REMOTE_ADDR'),
+                'remote_addr': environ.get('X_REAL_IP', environ.get('REMOTE_ADDR')),
                 'status': status_code,
                 'content_length': content_length,
                 'request_time': elapsed_time_milliseconds

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -39,8 +39,8 @@ class LoggingMiddleware(object):
                 'method': environ.get('REQUEST_METHOD'),
                 'path': environ.get('PATH_INFO'),
                 'query_string': environ.get('QUERY_STRING'),
-                'remote_addr': environ.get('X_REAL_IP', environ.get('REMOTE_ADDR')),
-                'x_forwarded_for': environ.get('X_FORWARDED_FOR'),
+                'remote_addr': environ.get('HTTP_X_REAL_IP', environ.get('REMOTE_ADDR')),
+                'x_forwarded_for': environ.get('HTTP_X_FORWARDED_FOR'),
                 'status': status_code,
                 'content_length': content_length,
                 'request_time': elapsed_time_milliseconds

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -40,6 +40,7 @@ class LoggingMiddleware(object):
                 'path': environ.get('PATH_INFO'),
                 'query_string': environ.get('QUERY_STRING'),
                 'remote_addr': environ.get('X_REAL_IP', environ.get('REMOTE_ADDR')),
+                'x_forwarded_for': environ.get('X_Forwarded_For'),
                 'status': status_code,
                 'content_length': content_length,
                 'request_time': elapsed_time_milliseconds

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -38,6 +38,17 @@ class FlaskRelayerTestCase(BaseTestCase):
         message['event_subtype'].should.equal('subtype')
         message['payload'].should.equal('payload')
 
+    def test_x_forwarded_for(self):
+        real_ip = '127.0.0.1'
+        ips = '127.0.0.1,192.168.99.100'
+        self.client.get('/test', headers={'X-Forwarded-For': ips, 'X-Real-IP': '127.0.0.1'})
+        messages = self._get_topic_messages('test_logging_topic')
+        messages.should.have.length_of(1)
+        message = json.loads(messages[0][0].decode('utf-8'))
+
+        message.should.have.key('x_forwarded_for').should.equal(ips)
+        message.should.have.key('remote_addr').should.equal(real_ip)
+
     def test_log(self):
         self.client.get('/test')
         messages = self._get_topic_messages('test_logging_topic')


### PR DESCRIPTION
Normally the `REMOTE_ADDR` brings the last address from the request and when there is a proxy the info will come from X_REAL_IP.

--
Please review:
- [x] @pablasso 
- [x] @albertein 

