### PR TITLE
Log topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ When you do a `relayer.emit` the message gets sent immediately to kafka, but als
 
 Both RPC and Flask relayer support the optional parameters `topic_prefix` and `topic_suffix`. When `topic_prefix` is present all message sent to any kafka topic will prepend the value of `topic_prefix` to the topic name, that includes both the logging topic value and the topics used on `emit` calls. `topic_suffix` does exactly the same but instead of prepending, it appends its value to the topic names, this might be useful to namespace topics if you want to use the same kafka cluster to host messages from a few different environments.
 
+Additionaly you can set `source` this becomes useful when you are logging from different places to the same kafka instance, alowing you to set a distinctive value. If not set, it defaults to `topic_prefix + logging_topic + topic_suffix`.
+
 
 ### Flask
 

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -8,10 +8,14 @@ __version__ = '0.0.3'
 
 class Relayer(object):
 
-    def __init__(self, logging_topic, context_handler_class, kafka_hosts=None, topic_prefix='', topic_suffix=''):
+    def __init__(self, logging_topic, context_handler_class, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
         self.logging_topic = logging_topic
         if not kafka_hosts:
             raise ConfigurationError()
+        if source == '':
+            self.source = '{0}{1}{2}'.format(topic_prefix, logging_topic, topic_suffix)
+        else:
+            self.source = source
         producer = KafkaProducer(bootstrap_servers=kafka_hosts)
         emitter = EventEmitter(producer, topic_prefix=topic_prefix, topic_suffix=topic_suffix)
         self.context = context_handler_class(emitter)

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -22,6 +22,7 @@ class Relayer(object):
 
     def emit(self, event_type, event_subtype, payload, partition_key=None):
         payload = {
+            'source': self.source,
             'event_type': event_type,
             'event_subtype': event_subtype,
             'payload': payload

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -5,15 +5,15 @@ from .logging_middleware import LoggingMiddleware
 
 class FlaskRelayer(object):
 
-    def __init__(self, app=None, logging_topic=None, kafka_hosts=None, topic_prefix='', topic_suffix=''):
+    def __init__(self, app=None, logging_topic=None, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
         if app:
             self.init_app(app, logging_topic, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
-                          topic_suffix=topic_suffix)
+                          topic_suffix=topic_suffix, source=source)
 
-    def init_app(self, app, logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix=''):
+    def init_app(self, app, logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
         kafka_hosts = kafka_hosts or app.config.get('KAFKA_HOSTS')
         self.event_relayer = Relayer(logging_topic, FlaskContextHandler, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
-                                     topic_suffix=topic_suffix)
+                                     topic_suffix=topic_suffix, source=source)
         app.wsgi_app = LoggingMiddleware(app, app.wsgi_app, self.event_relayer, logging_topic)
 
     def emit(self, *args, **kwargs):

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -14,7 +14,7 @@ class FlaskRelayer(object):
         kafka_hosts = kafka_hosts or app.config.get('KAFKA_HOSTS')
         self.event_relayer = Relayer(logging_topic, FlaskContextHandler, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
                                      topic_suffix=topic_suffix)
-        app.wsgi_app = LoggingMiddleware(app, app.wsgi_app, self.event_relayer.context, logging_topic)
+        app.wsgi_app = LoggingMiddleware(app, app.wsgi_app, self.event_relayer, logging_topic)
 
     def emit(self, *args, **kwargs):
         self.event_relayer.emit(*args, **kwargs)

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -34,6 +34,7 @@ class LoggingMiddleware(object):
             elapsed_time_milliseconds = elapsed_time.microseconds / 1000.0 + elapsed_time.seconds * 1000
 
             request_log = {
+                'logging_topic': self.logging_topic,
                 'date': start_time.isoformat(),
                 'user_agent': environ.get('HTTP_USER_AGENT'),
                 'method': environ.get('REQUEST_METHOD'),

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 
 class LoggingMiddleware(object):
-    def __init__(self, app, wsgi_app, context, logging_topic):
+    def __init__(self, app, wsgi_app, relayer, logging_topic):
         self.app = app
         self.wsgi_app = wsgi_app
-        self.context = context
+        self.relayer = relayer
         self.logging_topic = logging_topic
 
     def __call__(self, environ, start_response):
@@ -14,7 +14,7 @@ class LoggingMiddleware(object):
             status_code = None
             content_length = None
 
-            self.context.start_request()
+            self.relayer.context.start_request()
 
             def logging_start_response(status, response_headers, exc_info=None):
                 nonlocal status_code, content_length
@@ -47,6 +47,6 @@ class LoggingMiddleware(object):
                 'request_time': elapsed_time_milliseconds
             }
 
-            self.context.end_request(self.logging_topic, request_log)
+            self.relayer.context.end_request(self.logging_topic, request_log)
 
             return response

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -34,6 +34,7 @@ class LoggingMiddleware(object):
             elapsed_time_milliseconds = elapsed_time.microseconds / 1000.0 + elapsed_time.seconds * 1000
 
             request_log = {
+                'source': self.relayer.source,
                 'logging_topic': self.logging_topic,
                 'date': start_time.isoformat(),
                 'user_agent': environ.get('HTTP_USER_AGENT'),

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -18,6 +18,7 @@ def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suf
             service_response = function(*args, **kwargs)
             end_time = datetime.utcnow()
             request_log = {
+                'logging_topic': logging_topic,
                 'date': start_time.isoformat(),
                 'service': function.__qualname__,
                 'service_time': utils.get_elapsed_time_in_milliseconds(start_time, end_time)

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -4,10 +4,10 @@ from .rpc_context_handler import RPCContextHandler
 from datetime import datetime
 
 
-def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix=''):
+def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
 
     event_relayer = Relayer(logging_topic, RPCContextHandler, kafka_hosts=kafka_hosts,
-                            topic_prefix=topic_prefix, topic_suffix=topic_suffix)
+                            topic_prefix=topic_prefix, topic_suffix=topic_suffix, source=source)
     context = event_relayer.context
 
     def decorator(function):

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -18,6 +18,7 @@ def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suf
             service_response = function(*args, **kwargs)
             end_time = datetime.utcnow()
             request_log = {
+                'source': event_relayer.source,
                 'logging_topic': logging_topic,
                 'date': start_time.isoformat(),
                 'service': function.__qualname__,

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -31,12 +31,9 @@ class FlaskRelayerTestCase(BaseTestCase):
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
 
-        message.should.have.key('event_type')
-        message.should.have.key('event_subtype')
-        message.should.have.key('payload')
-        message['event_type'].should.equal('type')
-        message['event_subtype'].should.equal('subtype')
-        message['payload'].should.equal('payload')
+        message.should.have.key('event_type').being.equal('type')
+        message.should.have.key('event_subtype').being.equal('subtype')
+        message.should.have.key('payload').being.equal('payload')
 
     def test_x_forwarded_for(self):
         real_ip = '127.0.0.1'
@@ -54,6 +51,7 @@ class FlaskRelayerTestCase(BaseTestCase):
         messages = self._get_topic_messages('test_logging_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('logging_topic')
         message.should.have.key('date')
         message.should.have.key('user_agent')
         message.should.have.key('method')

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -51,6 +51,7 @@ class FlaskRelayerTestCase(BaseTestCase):
         messages = self._get_topic_messages('test_logging_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('source')
         message.should.have.key('logging_topic')
         message.should.have.key('date')
         message.should.have.key('user_agent')

--- a/tests/test_relayer.py
+++ b/tests/test_relayer.py
@@ -22,12 +22,10 @@ class TestRelayer(BaseTestCase):
         self.relayer.emit('type', 'subtype', 'payload', 'key')
         self.relayer.context.partition_key.should.equal('key')
         context_message = self.relayer.context.message
-        context_message.should.have.key('event_type')
-        context_message.should.have.key('event_subtype')
-        context_message.should.have.key('payload')
-        context_message['event_type'].should.equal('type')
-        context_message['event_subtype'].should.equal('subtype')
-        context_message['payload'].should.equal('payload')
+        context_message.should.have.key('source').which.should.equal(self.relayer.source)
+        context_message.should.have.key('event_type').which.should.equal('type')
+        context_message.should.have.key('event_subtype').which.should.equal('subtype')
+        context_message.should.have.key('payload').which.should.equal('payload')
 
     def test_log(self):
         self.relayer.log('info', 'message')

--- a/tests/test_relayer.py
+++ b/tests/test_relayer.py
@@ -36,3 +36,11 @@ class TestRelayer(BaseTestCase):
         log_message.should.have.key('payload')
         log_message['log_level'].should.equal('info')
         log_message['payload'].should.equal('message')
+
+    def test_source_not_present(self):
+        relayer = Relayer('log', MockedContextHandler, kafka_hosts='foo', topic_prefix='pre', topic_suffix='su')
+        relayer.source.should.equal('prelogsu')
+
+    def test_source(self):
+        relayer = Relayer('log', MockedContextHandler, kafka_hosts='foo', source='container_1')
+        relayer.source.should.equal('container_1')

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -41,6 +41,7 @@ class TestRPCRelayer(BaseTestCase):
         messages = self._get_topic_messages('test_logging_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('source')
         message.should.have.key('logging_topic')
         message.should.have.key('date')
         message.should.have.key('service')

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -41,6 +41,7 @@ class TestRPCRelayer(BaseTestCase):
         messages = self._get_topic_messages('test_logging_topic')
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('logging_topic')
         message.should.have.key('date')
         message.should.have.key('service')
         message.should.have.key('service_time')


### PR DESCRIPTION
When the logs are aggregated from different sources there is no distinctive of emitter.
Adding key `logging_topic` will allow us to have differentiator.
I know at that point it does not include the suffix and prefix but I'm not sure it is valuable, any thoughts on this?

--
Please review:
- @pablasso 
- @albertein 