### PR TITLE
Expose relayer instance

### DIFF
--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -27,4 +27,8 @@ def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suf
             context.end_request(logging_topic, request_log)
             return service_response
         return wrapper
+
+    # Expose relayer instance
+    decorator.instance = event_relayer
+
     return decorator

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -9,15 +9,25 @@ class TestRPCRelayer(BaseTestCase):
 
     def setUp(self):
         super().setUp()
-        relayer = make_rpc_relayer('logging', kafka_hosts='kafka', topic_prefix='test_', topic_suffix='_topic')
+        self.relayer_decorator = make_rpc_relayer('logging', kafka_hosts='kafka', topic_prefix='test_', topic_suffix='_topic')
+        self.logger = None
 
-        @relayer
+        def third_party_method():
+            if self.logger:
+                self.logger.log('info', 'here i am')
+
+        @self.relayer_decorator
         def rpc_method(value, relayer=None):
             relayer.emit('type', 'subtype', 'payload')
             relayer.log('info', 'message')
             return value
 
+        @self.relayer_decorator
+        def method_with_third_party(relayer=None):
+            third_party_method()
+
         self.rpc_method = rpc_method
+        self.method_with_third_party = method_with_third_party
 
     def test_input_and_output_works(self):
         self.rpc_method(True).should.be.true
@@ -57,3 +67,25 @@ class TestRPCRelayer(BaseTestCase):
         second_line.should.have.key('payload')
         second_line['log_level'].should.equal('info')
         second_line['payload'].should.equal('message')
+
+    def test_decorator_expose_instance(self):
+        self.relayer_decorator.should.have.property('instance')
+
+    def test_decorator_expose_instance_and_logs_correctly(self):
+        self.logger = self.relayer_decorator.instance
+        self.method_with_third_party()
+
+        messages = self._get_topic_messages('test_logging_topic')
+        messages.should.have.length_of(1)
+
+        message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('lines').which.should.have.length_of(1)
+
+    def test_decorator_expose_instance_and_log_only_when_instance_is_set(self):
+        self.method_with_third_party()
+
+        messages = self._get_topic_messages('test_logging_topic')
+        messages.should.have.length_of(1)
+
+        message = json.loads(messages[0][0].decode('utf-8'))
+        message.should.have.key('lines').which.should.have.length_of(0)

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -1,5 +1,6 @@
 import json
 
+from relayer import Relayer
 from relayer.rpc import make_rpc_relayer
 
 from . import BaseTestCase
@@ -70,6 +71,7 @@ class TestRPCRelayer(BaseTestCase):
 
     def test_decorator_expose_instance(self):
         self.relayer_decorator.should.have.property('instance')
+        self.relayer_decorator.instance.should.be.a(Relayer)
 
     def test_decorator_expose_instance_and_logs_correctly(self):
         self.logger = self.relayer_decorator.instance


### PR DESCRIPTION
Expose `relayer` instance so users are able to pass it to third party services that need it to aggregate logs or emit events.

---
Please review:
- @pablasso
- @iaserrat 
- @go-diego-go 
- @juanitobebe 