### PR TITLE
Add request id to the logged payload

### DIFF
--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -3,7 +3,7 @@ from kafka import KafkaProducer
 from .event_emitter import EventEmitter
 from .exceptions import ConfigurationError
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 class Relayer(object):

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -43,6 +43,7 @@ class LoggingMiddleware(object):
                 'query_string': environ.get('QUERY_STRING'),
                 'remote_addr': environ.get('HTTP_X_REAL_IP', environ.get('REMOTE_ADDR')),
                 'x_forwarded_for': environ.get('HTTP_X_FORWARDED_FOR'),
+                'request_id': environ.get('X_REQUEST_ID'),
                 'status': status_code,
                 'content_length': content_length,
                 'request_time': elapsed_time_milliseconds

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -70,6 +70,7 @@ class FlaskRelayerTestCase(BaseTestCase):
         message.should.have.key('method')
         message.should.have.key('path')
         message.should.have.key('query_string')
+        message.should.have.key('request_id')
         message.should.have.key('remote_addr')
         message.should.have.key('status')
         message.should.have.key('content_length')


### PR DESCRIPTION
We just added support to log the request id in the load balancer using:
```
proxy_set_header X-Request-Id $request_id;
```
within nginx

The main purpose of this is to more easily identify different service calls belonging to the same request.