### PR TITLE
Hotfix flask x request

### DIFF
--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -3,7 +3,7 @@ from kafka import KafkaProducer
 from .event_emitter import EventEmitter
 from .exceptions import ConfigurationError
 
-__version__ = '0.1.2'
+__version__ = '0.1.3'
 
 
 class Relayer(object):

--- a/relayer/flask/logging_middleware.py
+++ b/relayer/flask/logging_middleware.py
@@ -43,7 +43,7 @@ class LoggingMiddleware(object):
                 'query_string': environ.get('QUERY_STRING'),
                 'remote_addr': environ.get('HTTP_X_REAL_IP', environ.get('REMOTE_ADDR')),
                 'x_forwarded_for': environ.get('HTTP_X_FORWARDED_FOR'),
-                'request_id': environ.get('X_REQUEST_ID'),
+                'request_id': environ.get('HTTP_X_REQUEST_ID'),
                 'status': status_code,
                 'content_length': content_length,
                 'request_time': elapsed_time_milliseconds

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 
 import flask
 
@@ -46,6 +47,15 @@ class FlaskRelayerTestCase(BaseTestCase):
         messages.should.have.length_of(1)
         message = json.loads(messages[0][0].decode('utf-8'))
         message.should.equal('message')
+
+    def test_x_request_id(self):
+        request_id = str(uuid.uuid4())
+        self.client.get('/test', headers={'X-Request-ID': request_id})
+        messages = self._get_topic_messages('test_logging_topic')
+        messages.should.have.length_of(1)
+        message = json.loads(messages[0][0].decode('utf-8'))
+
+        message.should.have.key('request_id').should.equal(request_id)
 
     def test_x_forwarded_for(self):
         real_ip = '127.0.0.1'


### PR DESCRIPTION
Flask expose the headers under different names for the middle-wares and the request id was never logged.
Adding a test to cover that the request id is correctly logged.