### PR TITLE
Expose flush

### DIFF
--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -38,3 +38,6 @@ class Relayer(object):
             'payload': payload
         }
         self.context.log(message)
+
+    def flush(self, timeout=None):
+        self.emitter.flush(timeout=timeout)

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -16,9 +16,9 @@ class Relayer(object):
             self.source = '{0}{1}{2}'.format(topic_prefix, logging_topic, topic_suffix)
         else:
             self.source = source
-        producer = KafkaProducer(bootstrap_servers=kafka_hosts)
-        emitter = EventEmitter(producer, topic_prefix=topic_prefix, topic_suffix=topic_suffix)
-        self.context = context_handler_class(emitter)
+        self._producer = KafkaProducer(bootstrap_servers=kafka_hosts)
+        self._emitter = EventEmitter(self._producer, topic_prefix=topic_prefix, topic_suffix=topic_suffix)
+        self.context = context_handler_class(self._emitter)
 
     def emit(self, event_type, event_subtype, payload, partition_key=None):
         payload = {
@@ -40,4 +40,4 @@ class Relayer(object):
         self.context.log(message)
 
     def flush(self):
-        self.emitter.flush()
+        self._emitter.flush()

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -39,5 +39,5 @@ class Relayer(object):
         }
         self.context.log(message)
 
-    def flush(self, timeout=None):
-        self.emitter.flush(timeout=timeout)
+    def flush(self):
+        self.emitter.flush()

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -32,5 +32,5 @@ class EventEmitter(object):
 
         self.producer.send(topic, key=partition_key, value=message)
 
-    def flush(self):
-        self.producer.flush()
+    def flush(self, timeout=None):
+        self.producer.flush(timeout=timeout)

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -32,5 +32,5 @@ class EventEmitter(object):
 
         self.producer.send(topic, key=partition_key, value=message)
 
-    def flush(self, timeout=None):
-        self.producer.flush(timeout=timeout)
+    def flush(self):
+        self.producer.flush()

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -24,3 +24,6 @@ class FlaskRelayer(object):
 
     def log(self, *args, **kwargs):
         self.event_relayer.log(*args, **kwargs)
+
+    def flush(self, *args, **kwargs):
+        self.event_relayer.flush(*args, **kwargs)

--- a/relayer/flask/flask_context_handler.py
+++ b/relayer/flask/flask_context_handler.py
@@ -28,4 +28,3 @@ class FlaskContextHandler(object):
         log_entry['lines'] = ctx.kafka_producer_request_logs
 
         self.event_emitter.emit(logging_topic, log_entry)
-        self.event_emitter.flush()

--- a/relayer/rpc/rpc_context_handler.py
+++ b/relayer/rpc/rpc_context_handler.py
@@ -21,4 +21,3 @@ class RPCContextHandler(object):
         log_entry['lines'] = self.kafka_producer_request_logs
 
         self.event_emitter.emit(logging_topic, log_entry)
-        self.event_emitter.flush()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-kafka-python==1.2.1
+kafka-python==1.3.2

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -28,6 +28,12 @@ class FlaskRelayerTestCase(BaseTestCase):
             self.relayer.emit_raw('raw', 'message')
             return 'ok'
 
+        @app.route('/test_flush')
+        def test_log_and_flush():
+            self.relayer.log('info', 'message')
+            self.relayer.flush()
+            return 'ok'
+
     def test_request_works_fine(self):
         self.client.get('/test').status_code.should.equal(200)
 
@@ -96,3 +102,7 @@ class FlaskRelayerTestCase(BaseTestCase):
         second_line.should.have.key('payload')
         second_line['log_level'].should.equal('info')
         second_line['payload'].should.equal('message')
+
+    def test_flush(self):
+        self.client.get('/test_flush')
+        self.producer.flushed.should.be.true

--- a/tests/test_relayer.py
+++ b/tests/test_relayer.py
@@ -50,3 +50,7 @@ class TestRelayer(BaseTestCase):
         context_message = self.relayer.context.message
         context_message.should.be.a(str)
         context_message.should.equal('message')
+
+    def test_flush(self):
+        self.relayer.flush()
+        self.relayer._producer.flushed.should.be.true


### PR DESCRIPTION
Kafka producer have a flush method which is blocking. Since `relayer` is a tool it shouldn't manage blocking requests and just allow the user to interact with this interface.

I bumped the `kafka-python` version to latest (that typo in the commit). All interfaces we are using from it keep the same.