### PR TITLE
Support producer configuration

### DIFF
--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -7,6 +7,25 @@ __version__ = '0.1.3'
 
 
 class Relayer(object):
+    """
+    Arguments:
+        logging_topic: desired kafka topic to send logs, this will get modified if a prefix o suffix is set.
+        context_handler_class: class that receives an emitter and expose at least a method emit and log.
+    Keyword Arguments:
+        kafka_hosts: 'host[:port]' string (or list of 'host[:port]'
+            strings) that the producer should contact to bootstrap initial
+            cluster metadata. This does not have to be the full node list.
+            It just needs to have at least one broker that will respond to a
+            Metadata API Request.
+        topic_prefix (str): value to prefix all topics handled by relayer.
+            Defaults to empty string.
+        topic_suffix (str): value to suffix all topics handled by relayer.
+            Defaults to empty string.
+        source: If defined it must be a json serializable value.
+            Defaults to topic_prefix + logging_topic + topic_suffix.
+        producer_opts (dict): optional dictionary with the configuration
+            for http://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html
+    """
 
     def __init__(self, logging_topic, context_handler_class, **kwargs):
         self.logging_topic = logging_topic
@@ -22,7 +41,8 @@ class Relayer(object):
         else:
             self.source = kwargs.get('source')
 
-        self._producer = KafkaProducer(bootstrap_servers=kwargs.get('kafka_hosts'))
+        producer_opts = kwargs.get('producer_opts', {})
+        self._producer = KafkaProducer(bootstrap_servers=kwargs.get('kafka_hosts'), **producer_opts)
 
         self._emitter = EventEmitter(self._producer, topic_prefix=topic_prefix, topic_suffix=topic_suffix)
 

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -8,16 +8,24 @@ __version__ = '0.1.3'
 
 class Relayer(object):
 
-    def __init__(self, logging_topic, context_handler_class, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
+    def __init__(self, logging_topic, context_handler_class, **kwargs):
         self.logging_topic = logging_topic
-        if not kafka_hosts:
+
+        if 'kafka_hosts' not in kwargs:
             raise ConfigurationError()
-        if source == '':
+
+        topic_prefix = kwargs.get('topic_prefix', '')
+        topic_suffix = kwargs.get('topic_suffix', '')
+
+        if 'source' not in kwargs:
             self.source = '{0}{1}{2}'.format(topic_prefix, logging_topic, topic_suffix)
         else:
-            self.source = source
-        self._producer = KafkaProducer(bootstrap_servers=kafka_hosts)
+            self.source = kwargs.get('source')
+
+        self._producer = KafkaProducer(bootstrap_servers=kwargs.get('kafka_hosts'))
+
         self._emitter = EventEmitter(self._producer, topic_prefix=topic_prefix, topic_suffix=topic_suffix)
+
         self.context = context_handler_class(self._emitter)
 
     def emit(self, event_type, event_subtype, payload, partition_key=None):

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -3,7 +3,7 @@ from kafka import KafkaProducer
 from .event_emitter import EventEmitter
 from .exceptions import ConfigurationError
 
-__version__ = '0.1.3'
+__version__ = '0.2.0'
 
 
 class Relayer(object):

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -17,14 +17,14 @@ class Relayer(object):
             cluster metadata. This does not have to be the full node list.
             It just needs to have at least one broker that will respond to a
             Metadata API Request.
-        topic_prefix (str): value to prefix all topics handled by relayer.
+        topic_prefix: value to prefix all topics handled by relayer.
             Defaults to empty string.
-        topic_suffix (str): value to suffix all topics handled by relayer.
+        topic_suffix: value to suffix all topics handled by relayer.
             Defaults to empty string.
         source: This value will be added as a top level key in your payloads
             when using emit or log. If defined it must be a json serializable
             value. Defaults to topic_prefix + logging_topic + topic_suffix.
-        producer_opts (dict): optional dictionary with the configuration
+        producer_opts: optional dictionary with the configuration
             for http://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html
     """
 

--- a/relayer/__init__.py
+++ b/relayer/__init__.py
@@ -21,8 +21,9 @@ class Relayer(object):
             Defaults to empty string.
         topic_suffix (str): value to suffix all topics handled by relayer.
             Defaults to empty string.
-        source: If defined it must be a json serializable value.
-            Defaults to topic_prefix + logging_topic + topic_suffix.
+        source: This value will be added as a top level key in your payloads
+            when using emit or log. If defined it must be a json serializable
+            value. Defaults to topic_prefix + logging_topic + topic_suffix.
         producer_opts (dict): optional dictionary with the configuration
             for http://kafka-python.readthedocs.io/en/master/apidoc/KafkaProducer.html
     """

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -5,15 +5,23 @@ from .logging_middleware import LoggingMiddleware
 
 class FlaskRelayer(object):
 
-    def __init__(self, app=None, logging_topic=None, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
+    def __init__(self, app=None, logging_topic=None, kafka_hosts=None, **kwargs):
         if app:
-            self.init_app(app, logging_topic, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
-                          topic_suffix=topic_suffix, source=source)
+            self.init_app(
+                app,
+                logging_topic,
+                kafka_hosts=kafka_hosts,
+                **kwargs,
+            )
 
-    def init_app(self, app, logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
+    def init_app(self, app, logging_topic, kafka_hosts=None, **kwargs):
         kafka_hosts = kafka_hosts or app.config.get('KAFKA_HOSTS')
-        self.event_relayer = Relayer(logging_topic, FlaskContextHandler, kafka_hosts=kafka_hosts, topic_prefix=topic_prefix,
-                                     topic_suffix=topic_suffix, source=source)
+        self.event_relayer = Relayer(
+            logging_topic,
+            FlaskContextHandler,
+            kafka_hosts=kafka_hosts,
+            **kwargs,
+        )
         app.wsgi_app = LoggingMiddleware(app, app.wsgi_app, self.event_relayer, logging_topic)
 
     def emit(self, *args, **kwargs):

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -4,10 +4,14 @@ from .rpc_context_handler import RPCContextHandler
 from datetime import datetime
 
 
-def make_rpc_relayer(logging_topic, kafka_hosts=None, topic_prefix='', topic_suffix='', source=''):
+def make_rpc_relayer(logging_topic, kafka_hosts=None, **kwargs):
 
-    event_relayer = Relayer(logging_topic, RPCContextHandler, kafka_hosts=kafka_hosts,
-                            topic_prefix=topic_prefix, topic_suffix=topic_suffix, source=source)
+    event_relayer = Relayer(
+        logging_topic,
+        RPCContextHandler,
+        kafka_hosts=kafka_hosts,
+        **kwargs,
+    )
     context = event_relayer.context
 
     def decorator(function):


### PR DESCRIPTION
Use kwargs instead of explicitly have each key.
This will simplify the way we add new options to `relayer` since we had to define each kwargs for each interface defines (rpc and flask at the moment).
Allow to set `producer_opts` that will be passed to the kafka producer (from dpkp/kafka-python@1.3.2).