### PR TITLE
Add conditional import for support pip10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,11 @@
 import re
-from pip.req import parse_requirements
+
 from setuptools import setup, find_packages
+
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 
 def requirements(filename):


### PR DESCRIPTION
I have made this change so `.tox` could install relayer without problems in the repos

I used as reference the last post in this StackOverflow: https://stackoverflow.com/questions/25192794/no-module-named-pip-req