### PR TITLE
Feature - Add mypy type checking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
     - attach_workspace:
         at: ./
     - run:
-      name: Type Check (mypy)
-      command: pipenv run type_check
+        name: Type Check (mypy)
+        command: pipenv run type_check
     - store_artifacts:
         path: ./.mypy-report
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   fetch_dependencies:
     docker:
-    - image: ixai/pipenv:3.5
+    - image: ixai/pipenv:3.6
       environment:
         PIPENV_VENV_IN_PROJECT: "true"
     steps:
@@ -25,7 +25,7 @@ jobs:
         - .venv
   lint:
     docker:
-    - image: ixai/pipenv:3.5
+    - image: ixai/pipenv:3.6
       environment:
         PIPENV_VENV_IN_PROJECT: "true"
     steps:
@@ -37,7 +37,7 @@ jobs:
         command: pipenv run lint
   unit_test:
     docker:
-    - image: ixai/pipenv:3.5
+    - image: ixai/pipenv:3.6
       environment:
         PIPENV_VENV_IN_PROJECT: "true"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,13 @@ jobs:
     - checkout
     - restore_cache:
         keys:
-        - pipenv-deps-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
-        - pipenv-deps-{{ .Branch }}
-        - pipenv-deps-master
-        - pipenv-deps
+        - v1-pipenv-deps-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+        - v1-pipenv-deps-{{ .Branch }}
+        - v1-pipenv-deps-master
+        - v1-pipenv-deps
     - run: pipenv install -d
     - save_cache:
-        key: pipenv-deps-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+        key: v1-pipenv-deps-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
         paths:
         - .venv
     - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
         command: pipenv run test
   type_check:
     docker:
-    - image: python:3.6.4
+    - image: ixai/pipenv:3.6
       environment:
         PIPENV_VENV_IN_PROJECT: "true"
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,3 +75,6 @@ workflows:
     - unit_test:
         requires:
         - fetch_dependencies
+    - type_check:
+        requires:
+        - fetch_dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,22 @@ jobs:
     - run:
         name: Unit test (nose)
         command: pipenv run test
+  type_check:
+    docker:
+    - image: python:3.6.4
+      environment:
+        PIPENV_VENV_IN_PROJECT: "true"
+    steps:
+    - checkout
+    - attach_workspace:
+        at: ./
+    - run:
+      name: Type Check (mypy)
+      command: pipenv run type_check
+    - store_artifacts:
+      path: ./.mypy-report
+
+    
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
       name: Type Check (mypy)
       command: pipenv run type_check
     - store_artifacts:
-      path: ./.mypy-report
+        path: ./.mypy-report
 
     
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ man/
 .tox/
 .coverage
 cover/
+
+# mypy
+.mypy-report/
+.mypy_cache/

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 lint = "flake8 ."
 publish = "python setup.py sdist upload"
 test = "nosetests"
+type_check = "mypy ."
 
 [dev-packages]
 "flake8-debugger" = "*"
@@ -18,6 +19,8 @@ nose = "*"
 rednose = "*"
 sure = "*"
 Flask = "*"
+mypy = "*"
+lxml = "*"
 
 [packages]
 "e1839a8" = {path = ".", editable = true}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -222,10 +222,10 @@
         },
         "pbr": {
             "hashes": [
-                "sha256:680bf5ba9b28dd56e08eb7c267991a37c7a5f90a92c2e07108829931a50ff80a",
-                "sha256:6874feb22334a1e9a515193cba797664e940b763440c88115009ec323a7f2df5"
+                "sha256:3747c6f017f2dc099986c325239661948f9f5176f6880d9fdef164cb664cd665",
+                "sha256:a9c27eb8f0e24e786e544b2dbaedb729c9d8546342b5a6818d8eda098ad4340d"
             ],
-            "version": "==4.0.3"
+            "version": "==4.0.4"
         },
         "pep8-naming": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "425643c9dbf939105c393895bee8c8d7224c4858c959459cb5782a637df325e1"
+            "sha256": "e00202a855b91048b049a5437b130e3fc9ccbcff2ba1ec90a62b4f469fb7e624"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,10 +22,10 @@
         },
         "kafka-python": {
             "hashes": [
-                "sha256:6a5c516f540f4b13b78c64a85dd42dc38fe29257e2fae6393fc5daff9106389b",
-                "sha256:b5df584e200da5f814228a308a655c27d9c740ca83442910360c704679640a5f"
+                "sha256:078acdcd1fc6eddacc46d437c664998b4cf7613b7e79ced66a460965f2648f88",
+                "sha256:0b56f286b674dcb331d80c1d39a01a753cc3acc962bee707da5f207db74f0a26"
             ],
-            "version": "==1.4.2"
+            "version": "==1.4.3"
         },
         "six": {
             "hashes": [
@@ -149,6 +149,40 @@
             ],
             "version": "==2.10"
         },
+        "lxml": {
+            "hashes": [
+                "sha256:01c45df6d90497c20aa2a07789a41941f9a1029faa30bf725fc7f6d515b1afe9",
+                "sha256:0c9fef4f8d444e337df96c54544aeb85b7215b2ed7483bb6c35de97ac99f1bcd",
+                "sha256:0e3cd94c95d30ba9ca3cff40e9b2a14e1a10a4fd8131105b86c6b61648f57e4b",
+                "sha256:0e7996e9b46b4d8b4ac1c329a00e2d10edcd8380b95d2a676fccabf4c1dd0512",
+                "sha256:1858b1933d483ec5727549d3fe166eeb54229fbd6a9d3d7ea26d2c8a28048058",
+                "sha256:1b164bba1320b14905dcff77da10d5ce9c411ac4acc4fb4ed9a2a4d10fae38c9",
+                "sha256:1b46f37927fa6cd1f3fe34b54f1a23bd5bea1d905657289e08e1297069a1a597",
+                "sha256:231047b05907315ae9a9b6925751f9fd2c479cf7b100fff62485a25e382ca0d4",
+                "sha256:28f0c6652c1b130f1e576b60532f84b19379485eb8da6185c29bd8c9c9bc97bf",
+                "sha256:34d49d0f72dd82b9530322c48b70ac78cca0911275da741c3b1d2f3603c5f295",
+                "sha256:3682a17fbf72d56d7e46db2e80ca23850b79c28cfe75dcd9b82f58808f730909",
+                "sha256:3cf2830b9a6ad7f6e965fa53a768d4d2372a7856f20ffa6ce43d2fe9c0d34b19",
+                "sha256:5b653c9379ce29ce271fbe1010c5396670f018e78b643e21beefbb3dc6d291de",
+                "sha256:65a272821d5d8194358d6b46f3ca727fa56a6b63981606eac737c86d27309cdd",
+                "sha256:691f2cd97cf026c611df1ea5055755eec7f878f2d4f4330dc8686583de6fc5fd",
+                "sha256:6b6379495d3baacf7ed755ac68547c8dff6ce5d37bf370f0b7678888dc1283f9",
+                "sha256:75322a531504d4f383264391d89993a42e286da8821ddc5ac315e57305cb84f0",
+                "sha256:7f457cbda964257f443bac861d3a36732dcba8183149e7818ee2fb7c86901b94",
+                "sha256:7ff1fc76d8804e0f870c343a72007ff587090c218b0f92d8ee784ac2b6eaf5b9",
+                "sha256:8523fbde9c2216f3f2b950cb01ebe52e785eaa8a07ffeb456dd3576ca1b4fb9b",
+                "sha256:8f37627f16e026523fca326f1b5c9a43534862fede6c3e99c2ba6a776d75c1ab",
+                "sha256:a7182ea298cc3555ea56ffbb0748fe0d5e0d81451e2bc16d7f4645cd01b1ca70",
+                "sha256:abbd2fb4a5a04c11b5e04eb146659a0cf67bb237dd3d7ca3b9994d3a9f826e55",
+                "sha256:accc9f6b77bed0a6f267b4fae120f6008a951193d548cdbe9b61fc98a08b1cf8",
+                "sha256:bd88c8ce0d1504fdfd96a35911dd4f3edfb2e560d7cfdb5a3d09aa571ae5fbae",
+                "sha256:c557ad647facb3c0027a9d0af58853f905e85a0a2f04dcb73f8e665272fcdc3a",
+                "sha256:defabb7fbb99f9f7b3e0b24b286a46855caef4776495211b066e9e6592d12b04",
+                "sha256:e2629cdbcad82b83922a3488937632a4983ecc0fed3e5cfbf430d069382eeb9b"
+            ],
+            "index": "pypi",
+            "version": "==4.2.1"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
@@ -168,6 +202,14 @@
                 "sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba"
             ],
             "version": "==2.0.0"
+        },
+        "mypy": {
+            "hashes": [
+                "sha256:01cf289838f266ae7c6550c813181ee77d21eac9459dbf067e7a95a0a2db9721",
+                "sha256:bc251cb31bc236d9fe4bcc442c994c45fff2541f7161ee52dc949741fe9ca3dd"
+            ],
+            "index": "pypi",
+            "version": "==0.600"
         },
         "nose": {
             "hashes": [
@@ -233,6 +275,29 @@
                 "sha256:ef74b83698ea014112040cf32b1a093c1ab3d91c4dd18ecc03ec178fd99c9f9f"
             ],
             "version": "==0.1.11"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0948004fa228ae071054f5208840a1e88747a357ec1101c17217bfe99b299d58",
+                "sha256:25d8feefe27eb0303b73545416b13d108c6067b846b543738a25ff304824ed9a",
+                "sha256:29464a177d56e4e055b5f7b629935af7f49c196be47528cc94e0a7bf83fbc2b9",
+                "sha256:2e214b72168ea0275efd6c884b114ab42e316de3ffa125b267e732ed2abda892",
+                "sha256:3e0d5e48e3a23e9a4d1a9f698e32a542a4a288c871d33ed8df1b092a40f3a0f9",
+                "sha256:519425deca5c2b2bdac49f77b2c5625781abbaf9a809d727d3a5596b30bb4ded",
+                "sha256:57fe287f0cdd9ceaf69e7b71a2e94a24b5d268b35df251a88fef5cc241bf73aa",
+                "sha256:668d0cec391d9aed1c6a388b0d5b97cd22e6073eaa5fbaa6d2946603b4871efe",
+                "sha256:68ba70684990f59497680ff90d18e756a47bf4863c604098f10de9716b2c0bdd",
+                "sha256:6de012d2b166fe7a4cdf505eee3aaa12192f7ba365beeefaca4ec10e31241a85",
+                "sha256:79b91ebe5a28d349b6d0d323023350133e927b4de5b651a8aa2db69c761420c6",
+                "sha256:8550177fa5d4c1f09b5e5f524411c44633c80ec69b24e0e98906dd761941ca46",
+                "sha256:a8034021801bc0440f2e027c354b4eafd95891b573e12ff0418dec385c76785c",
+                "sha256:bc978ac17468fe868ee589c795d06777f75496b1ed576d308002c8a5756fb9ea",
+                "sha256:c05b41bc1deade9f90ddc5d988fe506208019ebba9f2578c622516fd201f5863",
+                "sha256:c9b060bd1e5a26ab6e8267fd46fc9e02b54eb15fffb16d112d4c7b1c12987559",
+                "sha256:edb04bdd45bfd76c8292c4d9654568efaedf76fe78eb246dde69bdb13b2dad87",
+                "sha256:f19f2a4f547505fe9072e15f6f4ae714af51b5a681a97f187971f50c283193b6"
+            ],
+            "version": "==1.1.0"
         },
         "werkzeug": {
             "hashes": [

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -1,4 +1,4 @@
-from typing import Any, AnyStr, Dict
+from typing import Any, Dict
 from datetime import datetime
 from uuid import UUID
 import json

--- a/relayer/event_emitter.py
+++ b/relayer/event_emitter.py
@@ -1,6 +1,9 @@
+from typing import Any, AnyStr, Dict
 from datetime import datetime
 from uuid import UUID
 import json
+
+from kafka import KafkaProducer
 
 from .exceptions import NonJSONSerializableMessageError, UnsupportedPartitionKeyTypeError
 from .logger import log_kafka_message
@@ -8,12 +11,12 @@ from .logger import log_kafka_message
 
 class EventEmitter(object):
 
-    def __init__(self, producer, topic_prefix='', topic_suffix=''):
+    def __init__(self, producer: KafkaProducer, topic_prefix: str = '', topic_suffix: str = '') -> None:
         self.producer = producer
         self.topic_prefix = topic_prefix
         self.topic_suffix = topic_suffix
 
-    def emit(self, topic, message, partition_key=None):
+    def emit(self, topic: str, message: Dict[Any, Any], partition_key: Any = None) -> None:
 
         topic = '{0}{1}{2}'.format(self.topic_prefix, topic, self.topic_suffix)
 
@@ -28,11 +31,11 @@ class EventEmitter(object):
 
         try:
             message.update({'timestamp': '{0}Z'.format(datetime.utcnow().isoformat())})
-            message = json.dumps(message).encode('utf-8')
+            msg = json.dumps(message).encode('utf-8')
         except (TypeError, AttributeError) as error:
             raise NonJSONSerializableMessageError(str(error))
 
-        self.producer.send(topic, key=partition_key, value=message)
+        self.producer.send(topic, key=partition_key, value=msg)
 
-    def flush(self):
+    def flush(self) -> None:
         self.producer.flush()

--- a/relayer/exceptions.py
+++ b/relayer/exceptions.py
@@ -1,3 +1,4 @@
+from typing import Any
 from uuid import UUID
 
 
@@ -10,11 +11,11 @@ class NonJSONSerializableMessageError(RelayerError):
 
 
 class ConfigurationError(RelayerError):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('Cannot create relayer object if no kafka hosts are provided')
 
 
 class UnsupportedPartitionKeyTypeError(RelayerError):
-    def __init__(self, provided_type):
+    def __init__(self, provided_type: Any) -> None:
         super().__init__('Unsuported partition key type provided, got {}, expected {} or {}'.format(
             provided_type.__name__, str.__name__, UUID.__name__))

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any
 
 from flask import Flask
 from relayer import Relayer

--- a/relayer/flask/__init__.py
+++ b/relayer/flask/__init__.py
@@ -1,9 +1,12 @@
+from typing import Dict, Any
+
+from flask import Flask
 from relayer import Relayer
 
 
 class FlaskRelayer(object):
 
-    def __init__(self, app=None, logging_topic=None, kafka_hosts=None, **kwargs):
+    def __init__(self, app: Flask, logging_topic: str, kafka_hosts: str = None, **kwargs: str) -> None:
         if app:
             self.init_app(
                 app,
@@ -12,7 +15,7 @@ class FlaskRelayer(object):
                 **kwargs,
             )
 
-    def init_app(self, app, logging_topic, kafka_hosts=None, **kwargs):
+    def init_app(self, app: Flask, logging_topic: str, kafka_hosts: str = None, **kwargs: str) -> None:
         kafka_hosts = kafka_hosts or app.config.get('KAFKA_HOSTS')
         self.event_relayer = Relayer(
             logging_topic,
@@ -20,14 +23,14 @@ class FlaskRelayer(object):
             **kwargs,
         )
 
-    def emit(self, *args, **kwargs):
+    def emit(self, *args: str, **kwargs: str) -> None:
         self.event_relayer.emit(*args, **kwargs)
 
-    def emit_raw(self, *args, **kwargs):
+    def emit_raw(self, *args: Any, **kwargs: Any) -> None:
         self.event_relayer.emit_raw(*args, **kwargs)
 
-    def log(self, *args, **kwargs):
+    def log(self, *args: str, **kwargs: str) -> None:
         self.event_relayer.log(*args, **kwargs)
 
-    def flush(self, *args, **kwargs):
-        self.event_relayer.flush(*args, **kwargs)
+    def flush(self, *args: str, **kwargs: str) -> None:
+        self.event_relayer.flush()

--- a/relayer/logger.py
+++ b/relayer/logger.py
@@ -1,7 +1,8 @@
+from typing import Dict, AnyStr, Any, Union
 from .logging import logger
 
 
-def log_kafka_message(topic, payload, partition_key=None):
+def log_kafka_message(topic: str, payload: Union[Dict[Any, Any], str], partition_key: str = None) -> None:
     if not isinstance(payload, dict):
         payload = {'message': payload}
     logger.debug('kafka_message', topic=topic, partition_key=partition_key, **payload)

--- a/relayer/logger.py
+++ b/relayer/logger.py
@@ -1,4 +1,4 @@
-from typing import Dict, AnyStr, Any, Union
+from typing import Dict, Any, Union
 from .logging import logger
 
 

--- a/relayer/logging.py
+++ b/relayer/logging.py
@@ -1,8 +1,9 @@
+from typing import Any
 import structlog
 
 
 logger = structlog.get_logger('wizeline.lib.relayer')
 
 
-def log_deprecation_notice(source=None):
+def log_deprecation_notice(source: str = None) -> None:
     logger.warn('deprecation_notice', source=source)

--- a/relayer/logging.py
+++ b/relayer/logging.py
@@ -1,4 +1,3 @@
-from typing import Any
 import structlog
 
 

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Tuple
+from typing import Any, Callable
 
 from datetime import datetime
 
@@ -37,6 +37,6 @@ def make_rpc_relayer(
     # Expose relayer instance
     # Adding attributes to Callable instances is not supported by mypy yet.
     # This is the issue tracking these scenarios: https://github.com/python/mypy/issues/2087
-    decorator.instance = event_relayer # type: ignore
+    decorator.instance = event_relayer  # type: ignore
 
     return decorator

--- a/relayer/rpc/__init__.py
+++ b/relayer/rpc/__init__.py
@@ -1,10 +1,16 @@
+from typing import Any, Callable, Dict, Tuple
+
 from datetime import datetime
 
 from relayer import Relayer, utils
 from relayer.logging import logger
 
 
-def make_rpc_relayer(logging_topic, kafka_hosts=None, **kwargs):
+def make_rpc_relayer(
+    logging_topic: str,
+    kafka_hosts: str = '',
+    **kwargs: str
+) -> Callable[..., Any]:
 
     event_relayer = Relayer(
         logging_topic,
@@ -12,8 +18,8 @@ def make_rpc_relayer(logging_topic, kafka_hosts=None, **kwargs):
         **kwargs,
     )
 
-    def decorator(function):
-        def wrapper(*args, **kwargs):
+    def decorator(function: Callable[..., Any]) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Callable[..., Any]:
             start_time = datetime.utcnow()
             kwargs['relayer'] = event_relayer
             service_response = function(*args, **kwargs)
@@ -29,6 +35,8 @@ def make_rpc_relayer(logging_topic, kafka_hosts=None, **kwargs):
         return wrapper
 
     # Expose relayer instance
-    decorator.instance = event_relayer
+    # Adding attributes to Callable instances is not supported by mypy yet.
+    # This is the issue tracking these scenarios: https://github.com/python/mypy/issues/2087
+    decorator.instance = event_relayer # type: ignore
 
     return decorator

--- a/relayer/test/mocked_producer.py
+++ b/relayer/test/mocked_producer.py
@@ -1,11 +1,10 @@
 from typing import Dict, Any, List, Tuple
-
 from collections import defaultdict
 
 
 class MockedProducer(object):
     def __init__(self) -> None:
-        self.produced_messages = defaultdict(list)  # type: Dict[Any, List[Tuple[Any, ...]]]
+        self.produced_messages: Dict[Any, List[Tuple[Any, ...]]] = defaultdict(list)
         self.flushed = False
 
     def send(self, topic: str, value: str = None, key: str = None) -> None:

--- a/relayer/test/mocked_producer.py
+++ b/relayer/test/mocked_producer.py
@@ -1,3 +1,5 @@
+from typing import Dict, Any, List, Tuple
+
 from collections import defaultdict
 
 

--- a/relayer/test/mocked_producer.py
+++ b/relayer/test/mocked_producer.py
@@ -1,13 +1,14 @@
+from typing import Dict, Any, List, Tuple
 from collections import defaultdict
 
 
 class MockedProducer(object):
-    def __init__(self):
-        self.produced_messages = defaultdict(list)
+    def __init__(self) -> None:
+        self.produced_messages = defaultdict(list) # type: Dict[Any, List[Tuple[Any, ...]]]
         self.flushed = False
 
-    def send(self, topic, value=None, key=None):
-        self.produced_messages[topic].append((value, key, ))
+    def send(self, topic: str, value: str = None, key: str = None) -> None:
+        self.produced_messages[topic].append((value, key))
 
-    def flush(self):
+    def flush(self) -> None:
         self.flushed = True

--- a/relayer/test/mocked_producer.py
+++ b/relayer/test/mocked_producer.py
@@ -1,10 +1,9 @@
-from typing import Dict, Any, List, Tuple
 from collections import defaultdict
 
 
 class MockedProducer(object):
     def __init__(self) -> None:
-        self.produced_messages = defaultdict(list) # type: Dict[Any, List[Tuple[Any, ...]]]
+        self.produced_messages = defaultdict(list)  # type: Dict[Any, List[Tuple[Any, ...]]]
         self.flushed = False
 
     def send(self, topic: str, value: str = None, key: str = None) -> None:

--- a/relayer/test/relayer_patch.py
+++ b/relayer/test/relayer_patch.py
@@ -5,13 +5,13 @@ from .mocked_producer import MockedProducer
 
 class RelayerPatch(object):
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.patcher = mock.patch('relayer.KafkaProducer')
 
-    def start(self):
+    def start(self) -> None:
         kafka_producer_mock = self.patcher.start()
         self.mocked_producer = MockedProducer()
         kafka_producer_mock.return_value = self.mocked_producer
 
-    def stop(self):
+    def stop(self) -> None:
         self.patcher.stop()

--- a/relayer/utils/__init__.py
+++ b/relayer/utils/__init__.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime
+
 
 def get_elapsed_time_in_milliseconds(start_time: datetime, end_time: datetime) -> float:
     elapsed_time = end_time - start_time

--- a/relayer/utils/__init__.py
+++ b/relayer/utils/__init__.py
@@ -1,3 +1,5 @@
-def get_elapsed_time_in_milliseconds(start_time, end_time):
+from datetime import datetime, timedelta
+
+def get_elapsed_time_in_milliseconds(start_time: datetime, end_time: datetime) -> float:
     elapsed_time = end_time - start_time
     return elapsed_time.microseconds / 1000.0 + elapsed_time.seconds * 1000

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,12 @@ cover-inclusive = 1
 cover-min-percentage = 99
 cover-package = relayer
 cover-html = 1
+
+[mypy]
+python_version = 3.6
+ignore_missing_imports = True
+disallow_untyped_defs = True
+show_column_numbers = True
+warn_redundant_casts = True
+disallow_any_generics = True
+html_report = .mypy-report

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,15 @@
+from typing import Optional
 import re
 from setuptools import setup, find_packages
 
 
-def get_version():
+def get_version() -> Optional[str]:
     with open('relayer/__init__.py', 'r') as f:
         version_regex = r'^__version__\s*=\s*[\'"](.+)[\'"]'
-        return re.search(version_regex, f.read(), re.MULTILINE).group(1)
-
+        result = re.search(version_regex, f.read(), re.MULTILINE)
+        if result:
+            return result.group(1)
+        return None
 
 setup(
     name='relayer',

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ def get_version() -> Optional[str]:
             return result.group(1)
         return None
 
+
 setup(
     name='relayer',
     version=get_version(),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+from typing import List, Any
 import sure  # noqa
 from unittest import TestCase
 
@@ -6,14 +7,14 @@ from relayer.test import RelayerPatch
 
 class BaseTestCase(TestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.relayer_patch = RelayerPatch()
         self.relayer_patch.start()
         self.producer = self.relayer_patch.mocked_producer
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         if hasattr(self, 'relayer_patch'):
             self.relayer_patch.stop()
 
-    def _get_topic_messages(self, topic):
+    def _get_topic_messages(self, topic: str) -> List[Any]:
         return self.producer.produced_messages[topic]

--- a/tests/test_flask_relayer.py
+++ b/tests/test_flask_relayer.py
@@ -12,7 +12,7 @@ TEST_VAL = 'bar_val'
 
 class FlaskRelayerTestCase(BaseTestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         app = flask.Flask(__name__)
         self.app = app
@@ -20,43 +20,46 @@ class FlaskRelayerTestCase(BaseTestCase):
         self.relayer = FlaskRelayer(app, 'logging', 'kafka', topic_prefix='test_', topic_suffix='_topic')
 
         @app.route('/test')
-        def test_emit():
+        def test_emit() -> str:
             self.relayer.emit('type', 'subtype', 'payload')
             self.relayer.log('info', 'message')
             return 'ok'
 
         @app.route('/test_raw')
-        def test_emit_raw():
+        def test_emit_raw() -> str:
             self.relayer.emit_raw('raw', {TEST_KEY: TEST_VAL})
             return 'ok'
 
         @app.route('/test_flush')
-        def test_log_and_flush():
+        def test_log_and_flush() -> str:
             self.relayer.log('info', 'message')
             self.relayer.flush()
             return 'ok'
 
-    def test_request_works_fine(self):
-        self.client.get('/test').status_code.should.equal(200)
+    def test_request_works_fine(self) -> None:
+        assert self.client.get('/test').status_code == 200
 
-    def test_emitted_messages(self):
+    def test_emitted_messages(self) -> None:
         self.client.get('/test')
         messages = self._get_topic_messages('test_type_topic')
-        messages.should.have.length_of(1)
+        assert len(messages) == 1
         message = json.loads(messages[0][0].decode('utf-8'))
 
-        message.should.have.key('event_type').being.equal('type')
-        message.should.have.key('event_subtype').being.equal('subtype')
-        message.should.have.key('payload').being.equal('payload')
+        assert 'event_type' in message
+        assert message['event_type'] == 'type'
+        assert 'event_subtype' in message
+        assert message['event_subtype'] == 'subtype'
+        assert 'payload' in message
+        assert message['payload'] == 'payload'
 
-    def test_emitted_raw_messages(self):
+    def test_emitted_raw_messages(self) -> None:
         self.client.get('/test_raw')
         messages = self._get_topic_messages('test_raw_topic')
-        messages.should.have.length_of(1)
+        assert len(messages) == 1
         message = json.loads(messages[0][0].decode('utf-8'))
-        message.should.contain(TEST_KEY)
-        message[TEST_KEY].should.equal(TEST_VAL)
+        assert TEST_KEY in message
+        assert message[TEST_KEY] == TEST_VAL
 
-    def test_flush(self):
+    def test_flush(self) -> None:
         self.client.get('/test_flush')
-        self.producer.flushed.should.be.true
+        assert self.producer.flushed

--- a/tests/test_relayer.py
+++ b/tests/test_relayer.py
@@ -6,30 +6,30 @@ from . import BaseTestCase
 
 class TestRelayer(BaseTestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.relayer = Relayer('log', kafka_hosts='foo')
 
-    def test_requires_kafka_hosts(self):
-        Relayer.when.called_with('foo').should.throw(ConfigurationError)
+    def test_requires_kafka_hosts(self) -> None:
+        self.assertRaises(ConfigurationError, Relayer, 'foo')
 
-    def test_emit(self):
+    def test_emit(self) -> None:
         self.relayer.emit('type', 'subtype', 'payload')
 
-    def test_emit_with_partition_key(self):
+    def test_emit_with_partition_key(self) -> None:
         self.relayer.emit('type', 'subtype', 'payload', 'key')
 
-    def test_source_not_present(self):
+    def test_source_not_present(self) -> None:
         relayer = Relayer('log', kafka_hosts='foo', topic_prefix='pre', topic_suffix='su')
-        relayer.source.should.equal('prelogsu')
+        assert relayer.source == 'prelogsu'
 
-    def test_source(self):
+    def test_source(self) -> None:
         relayer = Relayer('log', kafka_hosts='foo', source='container_1')
-        relayer.source.should.equal('container_1')
+        assert relayer.source == 'container_1'
 
-    def test_emit_raw(self):
+    def test_emit_raw(self) -> None:
         self.relayer.emit_raw('topic', {'message': 'content'}, 'key')
 
-    def test_flush(self):
+    def test_flush(self) -> None:
         self.relayer.flush()
-        self.relayer._producer.flushed.should.be.true
+        assert self.relayer._producer.flushed

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -1,4 +1,3 @@
-from typing import Any
 import json
 
 from relayer import Relayer
@@ -50,4 +49,4 @@ class TestRPCRelayer(BaseTestCase):
 
     def test_decorator_expose_instance(self) -> None:
         assert hasattr(self.relayer_decorator, 'instance')
-        assert isinstance(self.relayer_decorator.instance, Relayer) # type: ignore
+        assert isinstance(self.relayer_decorator.instance, Relayer)  # type: ignore

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -24,13 +24,24 @@ class TestRPCRelayer(BaseTestCase):
             return value
 
         @self.relayer_decorator
+        def rpc_payload_method(value: bool, relayer: Relayer) -> bool:
+            relayer.emit('type', 'subtype', 'payload')
+            relayer.log('info', {'message': 'this is a message'})
+            return value
+
+        @self.relayer_decorator
         def method_with_third_party(relayer: Relayer = None) -> None:
             third_party_method()
 
         self.rpc_method = rpc_method
+        self.rpc_payload_method = rpc_payload_method
         self.method_with_third_party = method_with_third_party
 
     def test_input_and_output_works(self) -> None:
+        assert self.rpc_payload_method(True)
+        assert not self.rpc_payload_method(False)
+
+    def test_input_and_output_with_payload_works(self) -> None:
         assert self.rpc_method(True)
         assert not self.rpc_method(False)
 

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -19,7 +19,7 @@ class TestRPCRelayer(BaseTestCase):
                 self.logger.log('info', 'here i am')
 
         @self.relayer_decorator
-        def rpc_method(value: Any, relayer: Relayer) -> Any:
+        def rpc_method(value: bool, relayer: Relayer) -> bool:
             relayer.emit('type', 'subtype', 'payload')
             relayer.log('info', 'message')
             return value
@@ -50,4 +50,4 @@ class TestRPCRelayer(BaseTestCase):
 
     def test_decorator_expose_instance(self) -> None:
         assert hasattr(self.relayer_decorator, 'instance')
-        assert isinstance(self.relayer_decorator.instance, Relayer)
+        assert isinstance(self.relayer_decorator.instance, Relayer) # type: ignore

--- a/tests/test_rpc_relayer.py
+++ b/tests/test_rpc_relayer.py
@@ -1,3 +1,4 @@
+from typing import Any
 import json
 
 from relayer import Relayer
@@ -8,45 +9,45 @@ from . import BaseTestCase
 
 class TestRPCRelayer(BaseTestCase):
 
-    def setUp(self):
+    def setUp(self) -> None:
         super().setUp()
         self.relayer_decorator = make_rpc_relayer('logging', kafka_hosts='kafka', topic_prefix='test_', topic_suffix='_topic')
         self.logger = None
 
-        def third_party_method():
+        def third_party_method() -> None:
             if self.logger:
                 self.logger.log('info', 'here i am')
 
         @self.relayer_decorator
-        def rpc_method(value, relayer=None):
+        def rpc_method(value: Any, relayer: Relayer) -> Any:
             relayer.emit('type', 'subtype', 'payload')
             relayer.log('info', 'message')
             return value
 
         @self.relayer_decorator
-        def method_with_third_party(relayer=None):
+        def method_with_third_party(relayer: Relayer = None) -> None:
             third_party_method()
 
         self.rpc_method = rpc_method
         self.method_with_third_party = method_with_third_party
 
-    def test_input_and_output_works(self):
-        self.rpc_method(True).should.be.true
-        self.rpc_method(False).should.be.false
+    def test_input_and_output_works(self) -> None:
+        assert self.rpc_method(True)
+        assert not self.rpc_method(False)
 
-    def test_emitted_messages(self):
+    def test_emitted_messages(self) -> None:
         self.rpc_method(True)
         messages = self._get_topic_messages('test_type_topic')
-        messages.should.have.length_of(1)
+        assert len(messages) == 1
         message = json.loads(messages[0][0].decode('utf-8'))
 
-        message.should.have.key('event_type')
-        message.should.have.key('event_subtype')
-        message.should.have.key('payload')
-        message['event_type'].should.equal('type')
-        message['event_subtype'].should.equal('subtype')
-        message['payload'].should.equal('payload')
+        assert 'event_type' in message
+        assert 'event_subtype' in message
+        assert 'payload' in message
+        assert message['event_type'] == 'type'
+        assert message['event_subtype'] == 'subtype'
+        assert message['payload'] == 'payload'
 
-    def test_decorator_expose_instance(self):
-        self.relayer_decorator.should.have.property('instance')
-        self.relayer_decorator.instance.should.be.a(Relayer)
+    def test_decorator_expose_instance(self) -> None:
+        assert hasattr(self.relayer_decorator, 'instance')
+        assert isinstance(self.relayer_decorator.instance, Relayer)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,11 +7,11 @@ from . import BaseTestCase
 
 class TestUtils(BaseTestCase):
 
-    def test_elapsed_time_in_milliseconds(self):
+    def test_elapsed_time_in_milliseconds(self) -> None:
         start_time = datetime(2016, 6, 21, 15, 12, 5, 500000)
         end_time = datetime(2016, 6, 21, 15, 12, 6, 600000)
         milliseconds = utils.get_elapsed_time_in_milliseconds(start_time, end_time)
-        milliseconds.should.equal(1100.0)
+        assert milliseconds == 1100.0
         end_time = datetime(2016, 6, 21, 15, 12, 6, 600500)
         milliseconds = utils.get_elapsed_time_in_milliseconds(start_time, end_time)
-        milliseconds.should.equal(1100.5)
+        assert milliseconds == 1100.5


### PR DESCRIPTION
Decorators are really annoying to type and if your add an attribute to a function, mypy cannot handled that. 
```python
def f():
    return 'hello'
f.x = 1 # not supported by mypy
```

This is why for this scenario I added an `# type: ignore` comment to that line.